### PR TITLE
Add `@test_pixelmatch` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+## 1.1.0 - 2025-12-01
+
+- Added the `@test_pixelmatch` macro which is a similar convenience macro to `@test_reference` from ReferenceTests.jl, just with a different naming scheme, the saving of diff images and displaying of a test difference viewer in VSCode.

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,17 @@
 name = "PixelMatch"
 uuid = "433bd86c-62cb-491d-a348-72c5c8365002"
+version = "1.1.0"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
-version = "1.0.0"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Base64 = "1"
 ColorTypes = "0.12"
+PNGFiles = "0.4"
+Test = "1"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ num_diff_pixels, diff_img = pixelmatch(img1, img2)
 # Save the diff image
 save("diff.png", diff_img)
 ```
+
+There's also a convenience macro `@test_pixelmatch`.
+It takes a path (without extension) relative to the place where it's called and a Julia expression whose output can be written to png. Then it checks that there are no different pixels, if there are and the `"juliavscode/html"` MIME type can be displayed (i.e. you're running tests in VSCode) an html diff viewer will be shown that is useful for comparing recording and reference.
+
+```julia
+@test_pixelmatch "relative/path/to/file" something_showable_as_png
+```
+
+Three files are written, `folder/name_rec.png`, `folder/name_ref.png` and if there's a difference, `folder/name_diff.png`. Both `*_rec.png` and `*_diff.png` should be added to `.gitignore`.

--- a/src/PixelMatch.jl
+++ b/src/PixelMatch.jl
@@ -1,6 +1,13 @@
 module PixelMatch
 
 using ColorTypes
+import PNGFiles
+import Base64
+import Test
+
+INTERACTIVE_MODE = Ref(true)
+
+export @test_pixelmatch
 
 export pixelmatch
 
@@ -14,7 +21,7 @@ Compare two equally sized images, pixel by pixel.
 # Arguments
 - `img1`: First image as a matrix of color values
 - `img2`: Second image as a matrix of color values
-- `threshold`: Matching threshold (0 to 1); smaller is more sensitive. `nothing` defaults to 0.1
+- `threshold`: Matching threshold (0 to 1); smaller is more sensitive, defaults to 0.1
 - `include_aa`: Whether to include anti-aliasing detection
 - `alpha`: Opacity of original image in diff output
 - `aa_color`: Color of anti-aliased pixels in diff output
@@ -26,7 +33,7 @@ Compare two equally sized images, pixel by pixel.
 A tuple of (number of mismatched pixels, diff image).
 """
 function pixelmatch(img1::AbstractMatrix{<:Colorant}, img2::AbstractMatrix{<:Colorant}; 
-                   threshold::Union{Real, Nothing}=0.1,
+                   threshold=0.1,
                    include_aa::Bool=false,
                    alpha::Real=0.1,
                    aa_color::Colorant=RGB(1.0, 1.0, 0.0),
@@ -35,7 +42,7 @@ function pixelmatch(img1::AbstractMatrix{<:Colorant}, img2::AbstractMatrix{<:Col
                    diff_mask::Bool=false)
     
     # Handle default threshold
-    actual_threshold = threshold === nothing ? 0.1 : threshold
+    actual_threshold::Float64 = threshold
     
     height, width = size(img1)
     
@@ -265,5 +272,7 @@ function draw_gray_pixel(pixel::RGBA{Float64}, alpha_blend::Real)
     
     return RGBA(val, val, val, 1.0)
 end
+
+include("test_macro.jl")
 
 end # module PixelMatch

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -54,7 +54,6 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
     end
     recorded = PNGFiles.load(rec_path)
 
-
     # for running the tests locally where isinteractive() returns true
     interactive = INTERACTIVE_MODE[] && isinteractive()
 

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -98,7 +98,7 @@ function _test_pixelmatch(path_stem::String, recorded::AbstractMatrix{<:ColorTyp
                         elseif interactive
                             # Display HTML diff viewer if available
                             if Base.displayable(MIME("juliavscode/html"))
-                                _show_html_diff(; name, num_pixels_diff, ref_path, rec_path, diff_path)
+                                display(MIME("juliavscode/html"), html_diff_viewer(; name, num_pixels_diff, ref_path, rec_path, diff_path))
                             end
                             print("Replace reference with recorded result? (y/n): ")
                             response = readline()
@@ -120,11 +120,17 @@ function _test_pixelmatch(path_stem::String, recorded::AbstractMatrix{<:ColorTyp
     end
 end
 
-function _show_html_diff(; name, num_pixels_diff, ref_path, rec_path, diff_path)
+function html_diff_viewer(; name, num_pixels_diff, ref_path, rec_path, diff_path, shorten_embeds = false)
     # Convert images to base64 for HTML display
     ref_b64 = Base64.base64encode(read(ref_path))
     rec_b64 = Base64.base64encode(read(rec_path))
     diff_b64 = Base64.base64encode(read(diff_path))
+
+    if shorten_embeds
+        ref_b64 = first(ref_b64, 100)
+        rec_b64 = first(rec_b64, 100)
+        diff_b64 = first(diff_b64, 100)
+    end
 
     html_content = """
     <div style="font-family: Arial, sans-serif; padding: 20px;">
@@ -137,9 +143,9 @@ function _show_html_diff(; name, num_pixels_diff, ref_path, rec_path, diff_path)
         </div>
         
         <div style="border: 2px solid #ddd; border-radius: 8px; padding: 10px; background: #f8f9fa; max-width: 100%; overflow: auto;">
-            <img id="img-recorded" src="data:image/png;base64,\$rec_b64" style="max-width: 100%; height: auto; display: none;" />
-            <img id="img-reference" src="data:image/png;base64,\$ref_b64" style="max-width: 100%; height: auto; display: none;" />
-            <img id="img-diff" src="data:image/png;base64,\$diff_b64" style="max-width: 100%; height: auto; display: block;" />
+            <img id="img-recorded" src="data:image/png;base64,$rec_b64" style="max-width: 100%; height: auto; display: none;" />
+            <img id="img-reference" src="data:image/png;base64,$ref_b64" style="max-width: 100%; height: auto; display: none;" />
+            <img id="img-diff" src="data:image/png;base64,$diff_b64" style="max-width: 100%; height: auto; display: block;" />
         </div>
         
         <script>
@@ -206,5 +212,5 @@ function _show_html_diff(; name, num_pixels_diff, ref_path, rec_path, diff_path)
     </div>
     """
 
-    return display(MIME("juliavscode/html"), html_content)
+    return html_content
 end

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -35,7 +35,7 @@ macro test_pixelmatch_fails(name, expr, numpixels, kwargs...)
     end
 end
 
-function _test_pixelmatch(path_stem::String, recorded::AbstractMatrix{<:ColorTypes.Colorant}; test_pixel_mismatch::Union{Integer,Nothing} = nothing, kwargs...)
+function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch::Union{Integer,Nothing} = nothing, kwargs...)
     update = tryparse(Bool, get(ENV, "JULIA_REFERENCETESTS_UPDATE", "false")) === true
     
     ref_path = path_stem * "_ref.png"
@@ -45,8 +45,15 @@ function _test_pixelmatch(path_stem::String, recorded::AbstractMatrix{<:ColorTyp
     name = basename(path_stem)
     mkpath(dirname(path_stem))
 
-    # Save recorded image
-    PNGFiles.save(rec_path, recorded)
+    if obj_to_record isa AbstractMatrix{<:Colorant}
+        PNGFiles.save(rec_path, obj_to_record)
+    else
+        open(rec_path, "w") do io
+            show(io, MIME"image/png"(), obj_to_record)
+        end
+    end
+    recorded = PNGFiles.load(rec_path)
+
 
     # for running the tests locally where isinteractive() returns true
     interactive = INTERACTIVE_MODE[] && isinteractive()

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -1,0 +1,210 @@
+"""
+    @test_pixelmatch name image [keyword args...]
+
+Compare an image against a reference file using PixelMatch. The `name` should be
+the path stem without extension (`_suffix.png` is added automatically).
+
+Files created:
+- `name_ref.png` - reference image
+- `name_rec.png` - recorded/actual image (when test runs)
+- `name_diff.png` - diff image (when images differ)
+
+If the reference doesn't exist, it will be created. If images differ, an 
+interactive HTML diff viewer is shown (when available in VSCode) and the 
+user is prompted to update the reference.
+
+Use `JULIA_REFERENCETESTS_UPDATE=true` to force-update all references without prompting.
+
+# Example
+```julia
+@test_pixelmatch "references/my_plot" render(fig)
+```
+"""
+macro test_pixelmatch(name, expr, kwargs...)
+    dir = Base.source_dir()
+    quote
+        _test_pixelmatch(abspath(joinpath($dir, $(esc(name)))), $(esc(expr)); $(esc.(kwargs)...))
+    end
+end
+
+macro test_pixelmatch_fails(name, expr, numpixels, kwargs...)
+    dir = Base.source_dir()
+    quote
+        test_pixel_mismatch = $(esc(numpixels))
+        _test_pixelmatch(abspath(joinpath($dir, $(esc(name)))), $(esc(expr)); $(esc.(kwargs)...), test_pixel_mismatch)
+    end
+end
+
+function _test_pixelmatch(path_stem::String, recorded::AbstractMatrix{<:ColorTypes.Colorant}; test_pixel_mismatch::Union{Integer,Nothing} = nothing, kwargs...)
+    update = tryparse(Bool, get(ENV, "JULIA_REFERENCETESTS_UPDATE", "false")) === true
+    
+    ref_path = path_stem * "_ref.png"
+    rec_path = path_stem * "_rec.png"
+    diff_path = path_stem * "_diff.png"
+    
+    name = basename(path_stem)
+    mkpath(dirname(path_stem))
+
+    # Save recorded image
+    PNGFiles.save(rec_path, recorded)
+
+    # for running the tests locally where isinteractive() returns true
+    interactive = INTERACTIVE_MODE[] && isinteractive()
+
+    Test.@testset "$name" begin
+        reference_exists = isfile(ref_path)
+
+        if !reference_exists
+            if interactive || update
+                @info "Creating missing reference image: $ref_path"
+                cp(rec_path, ref_path; force = true)
+            else
+                Test.@test reference_exists
+            end
+        else
+            # Load reference image
+            img_ref = PNGFiles.load(ref_path)
+
+            if size(img_ref) != size(recorded)
+                if update
+                    @info "Reference size $(size(img_ref)) does not match recorded size $(size(recorded)) and JULIA_REFERENCETESTS_UPDATE=true, updating reference image"
+                    PNGFiles.save(ref_path, recorded)
+                else
+                    Test.@test size(img_ref) != size(recorded)
+                end
+            else
+                # Compare images using PixelMatch
+                num_pixels_diff, diff_image = pixelmatch(img_ref, recorded; kwargs...)
+
+                if test_pixel_mismatch !== nothing
+                    test_pixel_mismatch <= 0 && error("The number of expected mismatching pixels must be larger than zero, was $test_pixel_mismatch")
+                    Test.@test test_pixel_mismatch == num_pixels_diff
+                    PNGFiles.save(diff_path, diff_image)
+                else
+                    if num_pixels_diff > 0
+                        # Save diff image
+                        PNGFiles.save(diff_path, diff_image)
+
+                        # Print paths for inspection
+                        println("Reference test failed: $name")
+                        println("  Reference: $ref_path")
+                        println("  Recorded:    $rec_path")
+                        println("  Diff:      $diff_path")
+                        println("  Pixels different: $num_pixels_diff")
+
+                        if update
+                            @info "JULIA_REFERENCETESTS_UPDATE=true, updating reference image"
+                            cp(rec_path, ref_path; force = true)
+                        elseif interactive
+                            # Display HTML diff viewer if available
+                            if Base.displayable(MIME("juliavscode/html"))
+                                _show_html_diff(; name, num_pixels_diff, ref_path, rec_path, diff_path)
+                            end
+                            print("Replace reference with recorded result? (y/n): ")
+                            response = readline()
+                            if lowercase(strip(response)) == "y"
+                                cp(rec_path, ref_path; force = true)
+                                @info "Reference image updated."
+                            else
+                                Test.@test num_pixels_diff == 0
+                            end
+                        else
+                            Test.@test num_pixels_diff == 0
+                        end
+                    else
+                        Test.@test num_pixels_diff == 0
+                    end
+                end
+            end
+        end
+    end
+end
+
+function _show_html_diff(; name, num_pixels_diff, ref_path, rec_path, diff_path)
+    # Convert images to base64 for HTML display
+    ref_b64 = Base64.base64encode(read(ref_path))
+    rec_b64 = Base64.base64encode(read(rec_path))
+    diff_b64 = Base64.base64encode(read(diff_path))
+
+    html_content = """
+    <div style="font-family: Arial, sans-serif; padding: 20px;">
+        <h3>Image Comparison Failed: $(name)</h3>
+        <p><strong>Pixels different:</strong> $num_pixels_diff</p>
+        
+        <div style="margin: 10px 0;">
+            <button onclick="toggleRecordedReference()" id="btn-toggle" style="margin-right: 10px; padding: 8px 16px; background: #6c757d; color: white; border: none; border-radius: 4px; cursor: pointer;">Show Recorded</button>
+            <button onclick="showDiff()" id="btn-diff" style="padding: 8px 16px; background: #dc3545; color: white; border: none; border-radius: 4px; cursor: pointer;">Diff</button>
+        </div>
+        
+        <div style="border: 2px solid #ddd; border-radius: 8px; padding: 10px; background: #f8f9fa; max-width: 100%; overflow: auto;">
+            <img id="img-recorded" src="data:image/png;base64,\$rec_b64" style="max-width: 100%; height: auto; display: none;" />
+            <img id="img-reference" src="data:image/png;base64,\$ref_b64" style="max-width: 100%; height: auto; display: none;" />
+            <img id="img-diff" src="data:image/png;base64,\$diff_b64" style="max-width: 100%; height: auto; display: block;" />
+        </div>
+        
+        <script>
+            let showingRecorded = true;
+            let showingDiff = true;
+            
+            function updateToggleButton() {
+                if (showingDiff) {
+                    document.getElementById('btn-toggle').textContent = showingRecorded ? 'Show Recorded' : 'Show Reference';
+                } else {
+                    document.getElementById('btn-toggle').textContent = showingRecorded ? 'Showing Recorded' : 'Showing Reference';
+                }
+            }
+            
+            function toggleRecordedReference() {
+                if (showingDiff) {
+                    // If showing diff, switch back to current recorded/reference view without toggling
+                    document.getElementById('img-diff').style.display = 'none';
+                    document.getElementById('btn-diff').style.background = '#6c757d';
+                    showingDiff = false;
+                    
+                    // Show current state (don't toggle)
+                    if (showingRecorded) {
+                        document.getElementById('img-recorded').style.display = 'block';
+                        document.getElementById('img-reference').style.display = 'none';
+                    } else {
+                        document.getElementById('img-recorded').style.display = 'none';
+                        document.getElementById('img-reference').style.display = 'block';
+                    }
+                } else {
+                    // Normal toggle between recorded and reference
+                    if (showingRecorded) {
+                        // Switch to reference
+                        document.getElementById('img-recorded').style.display = 'none';
+                        document.getElementById('img-reference').style.display = 'block';
+                        showingRecorded = false;
+                    } else {
+                        // Switch to recorded
+                        document.getElementById('img-reference').style.display = 'none';
+                        document.getElementById('img-recorded').style.display = 'block';
+                        showingRecorded = true;
+                    }
+                }
+                
+                updateToggleButton();
+                document.getElementById('btn-toggle').style.background = '#007acc';
+            }
+            
+            function showDiff() {
+                // Hide recorded/reference images
+                document.getElementById('img-recorded').style.display = 'none';
+                document.getElementById('img-reference').style.display = 'none';
+                document.getElementById('img-diff').style.display = 'block';
+                
+                // Update button styles
+                document.getElementById('btn-toggle').style.background = '#6c757d';
+                document.getElementById('btn-diff').style.background = '#dc3545';
+                showingDiff = true;
+            }
+            
+            // Initialize button text
+            updateToggleButton();
+        </script>
+    </div>
+    """
+
+    return display(MIME("juliavscode/html"), html_content)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,10 +1,11 @@
 [deps]
-PixelMatch = "433bd86c-62cb-491d-a348-72c5c8365002"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
+PixelMatch = "433bd86c-62cb-491d-a348-72c5c8365002"
+ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 PixelMatch = {path = ".."}

--- a/test/html_diff_viewer
+++ b/test/html_diff_viewer
@@ -1,0 +1,77 @@
+<div style="font-family: Arial, sans-serif; padding: 20px;">
+    <h3>Image Comparison Failed: Different</h3>
+    <p><strong>Pixels different:</strong> 143</p>
+    
+    <div style="margin: 10px 0;">
+        <button onclick="toggleRecordedReference()" id="btn-toggle" style="margin-right: 10px; padding: 8px 16px; background: #6c757d; color: white; border: none; border-radius: 4px; cursor: pointer;">Show Recorded</button>
+        <button onclick="showDiff()" id="btn-diff" style="padding: 8px 16px; background: #dc3545; color: white; border: none; border-radius: 4px; cursor: pointer;">Diff</button>
+    </div>
+    
+    <div style="border: 2px solid #ddd; border-radius: 8px; padding: 10px; background: #f8f9fa; max-width: 100%; overflow: auto;">
+        <img id="img-recorded" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAEACAYAAADFkM5nAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYA" style="max-width: 100%; height: auto; display: none;" />
+        <img id="img-reference" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAEACAYAAADFkM5nAABoHklEQVR4AezBCYDVc+IA8M/vzZtpjuZqmg6VZJIOKdUWq0RWSM60" style="max-width: 100%; height: auto; display: none;" />
+        <img id="img-diff" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAEACAYAAADFkM5nAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYA" style="max-width: 100%; height: auto; display: block;" />
+    </div>
+    
+    <script>
+        let showingRecorded = true;
+        let showingDiff = true;
+        
+        function updateToggleButton() {
+            if (showingDiff) {
+                document.getElementById('btn-toggle').textContent = showingRecorded ? 'Show Recorded' : 'Show Reference';
+            } else {
+                document.getElementById('btn-toggle').textContent = showingRecorded ? 'Showing Recorded' : 'Showing Reference';
+            }
+        }
+        
+        function toggleRecordedReference() {
+            if (showingDiff) {
+                // If showing diff, switch back to current recorded/reference view without toggling
+                document.getElementById('img-diff').style.display = 'none';
+                document.getElementById('btn-diff').style.background = '#6c757d';
+                showingDiff = false;
+                
+                // Show current state (don't toggle)
+                if (showingRecorded) {
+                    document.getElementById('img-recorded').style.display = 'block';
+                    document.getElementById('img-reference').style.display = 'none';
+                } else {
+                    document.getElementById('img-recorded').style.display = 'none';
+                    document.getElementById('img-reference').style.display = 'block';
+                }
+            } else {
+                // Normal toggle between recorded and reference
+                if (showingRecorded) {
+                    // Switch to reference
+                    document.getElementById('img-recorded').style.display = 'none';
+                    document.getElementById('img-reference').style.display = 'block';
+                    showingRecorded = false;
+                } else {
+                    // Switch to recorded
+                    document.getElementById('img-reference').style.display = 'none';
+                    document.getElementById('img-recorded').style.display = 'block';
+                    showingRecorded = true;
+                }
+            }
+            
+            updateToggleButton();
+            document.getElementById('btn-toggle').style.background = '#007acc';
+        }
+        
+        function showDiff() {
+            // Hide recorded/reference images
+            document.getElementById('img-recorded').style.display = 'none';
+            document.getElementById('img-reference').style.display = 'none';
+            document.getElementById('img-diff').style.display = 'block';
+            
+            // Update button styles
+            document.getElementById('btn-toggle').style.background = '#6c757d';
+            document.getElementById('btn-diff').style.background = '#dc3545';
+            showingDiff = true;
+        }
+        
+        // Initialize button text
+        updateToggleButton();
+    </script>
+</div>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,12 @@ function diff_test(img_path1::String, img_path2::String, diff_path::String, opti
     @test output_rgba == expected_rgba
 end
 
+struct PNG
+    path::String
+end
+
+Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, read(p.path))
+
 @testset "PixelMatch.jl Tests" begin
     
     # Test all the exact same cases as in the JavaScript tests
@@ -146,6 +152,9 @@ end
                 @test isfile(rec_path)
                 diff_path = joinpath(test_dir, "matching_diff.png")
                 @test !isfile(diff_path)
+
+                # check if an object that can be shown as image/png also works
+                @test_pixelmatch joinpath(foldername, "matching") PNG(joinpath(test_dir, "matching_ref.png"))
 
                 # copy same image as before to a different name to get different rec/diff images
                 ref_path2 = joinpath(test_dir, "different_ref.png")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,41 +130,45 @@ end
         test_dir = joinpath(@__DIR__, foldername)
         mkpath(test_dir)
         
-        try
-            test_image = read_image("1a")
-            different_image = read_image("1b")
-            diff_between_both = read_image("1diff")
+        # change out of the test folder just to see that the relative paths in @test_pixelmatch
+        # are actually resolved relative to the macro placement and not pwd
+        cd("..") do
+            try
+                test_image = read_image("1a")
+                different_image = read_image("1b")
+                diff_between_both = read_image("1diff")
 
-            ref_path = joinpath(test_dir, "matching_ref.png")
-            cp(joinpath(@__DIR__, "fixtures", "1a.png"), ref_path)
-            
-            @test_pixelmatch joinpath(foldername, "matching") test_image
-            rec_path = joinpath(test_dir, "matching_rec.png")
-            @test isfile(rec_path)
-            diff_path = joinpath(test_dir, "matching_diff.png")
-            @test !isfile(diff_path)
+                ref_path = joinpath(test_dir, "matching_ref.png")
+                cp(joinpath(@__DIR__, "fixtures", "1a.png"), ref_path)
+                
+                @test_pixelmatch joinpath(foldername, "matching") test_image
+                rec_path = joinpath(test_dir, "matching_rec.png")
+                @test isfile(rec_path)
+                diff_path = joinpath(test_dir, "matching_diff.png")
+                @test !isfile(diff_path)
 
-            # copy same image as before to a different name to get different rec/diff images
-            ref_path2 = joinpath(test_dir, "different_ref.png")
-            cp(joinpath(@__DIR__, "fixtures", "1a.png"), ref_path2)
-            
-            rec_path2 = joinpath(test_dir, "different_rec.png")
-            diff_path2 = joinpath(test_dir, "different_diff.png")
-            @test_pixelmatch_fails joinpath(foldername, "different") different_image 143 threshold=0.05
+                # copy same image as before to a different name to get different rec/diff images
+                ref_path2 = joinpath(test_dir, "different_ref.png")
+                cp(joinpath(@__DIR__, "fixtures", "1a.png"), ref_path2)
+                
+                rec_path2 = joinpath(test_dir, "different_rec.png")
+                diff_path2 = joinpath(test_dir, "different_diff.png")
+                @test_pixelmatch_fails joinpath(foldername, "different") different_image 143 threshold=0.05
 
-            @test_reference joinpath(@__DIR__, "html_diff_viewer") PixelMatch.html_diff_viewer(; name = "Different", num_pixels_diff = 143, ref_path = ref_path2, rec_path = rec_path2, diff_path = diff_path2, shorten_embeds = true)
-            # whether the viewer works can only be checked manually
-            if isinteractive() && Base.displayable(MIME("juliavscode/html"))
-                display(MIME("juliavscode/html"), PixelMatch.html_diff_viewer(; name = "Different", num_pixels_diff = 143, ref_path = ref_path2, rec_path = rec_path2, diff_path = diff_path2))
+                @test_reference joinpath(@__DIR__, "html_diff_viewer") PixelMatch.html_diff_viewer(; name = "Different", num_pixels_diff = 143, ref_path = ref_path2, rec_path = rec_path2, diff_path = diff_path2, shorten_embeds = true)
+                # whether the viewer works can only be checked manually
+                if isinteractive() && Base.displayable(MIME("juliavscode/html"))
+                    display(MIME("juliavscode/html"), PixelMatch.html_diff_viewer(; name = "Different", num_pixels_diff = 143, ref_path = ref_path2, rec_path = rec_path2, diff_path = diff_path2))
+                end
+                
+                @test isfile(rec_path2)
+                @test isfile(diff_path2)
+                
+                cp(diff_path2, joinpath(test_dir, "diff_ref.png"))
+                @test_pixelmatch joinpath(foldername, "diff") diff_between_both
+            finally
+                rm(test_dir; recursive=true, force=true)
             end
-            
-            @test isfile(rec_path2)
-            @test isfile(diff_path2)
-            
-            cp(diff_path2, joinpath(test_dir, "diff_ref.png"))
-            @test_pixelmatch joinpath(foldername, "diff") diff_between_both
-        finally
-            rm(test_dir; recursive=true, force=true)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,11 @@
 using Test
 using PixelMatch
+using PixelMatch: @test_pixelmatch_fails
 using ColorTypes
 using FileIO
 using PNGFiles
+
+PixelMatch.INTERACTIVE_MODE[] = false
 
 # Helper function to read PNG images
 function read_image(name::String)
@@ -119,5 +122,42 @@ end
         img2 = fill(RGBA(0.5, 0.5, 0.5, 1.0), 5, 5)
         
         @test_throws ArgumentError pixelmatch(img1, img2)
+    end
+
+    @testset "@test_pixelmatch macro" begin
+        foldername = "macro_test_temp"
+        test_dir = joinpath(@__DIR__, foldername)
+        mkpath(test_dir)
+        
+        try
+            test_image = read_image("1a")
+            different_image = read_image("1b")
+            diff_between_both = read_image("1diff")
+
+            ref_path = joinpath(test_dir, "matching_ref.png")
+            cp(joinpath(@__DIR__, "fixtures", "1a.png"), ref_path)
+            
+            @test_pixelmatch joinpath(foldername, "matching") test_image
+            rec_path = joinpath(test_dir, "matching_rec.png")
+            @test isfile(rec_path)
+            diff_path = joinpath(test_dir, "matching_diff.png")
+            @test !isfile(diff_path)
+
+            # copy same image as before to a different name to get different rec/diff images
+            ref_path2 = joinpath(test_dir, "different_ref.png")
+            cp(joinpath(@__DIR__, "fixtures", "1a.png"), ref_path2)
+            
+            rec_path2 = joinpath(test_dir, "different_rec.png")
+            diff_path2 = joinpath(test_dir, "different_diff.png")
+            @test_pixelmatch_fails joinpath(foldername, "different") different_image 143 threshold=0.05
+            
+            @test isfile(rec_path2)
+            @test isfile(diff_path2)
+            
+            cp(diff_path2, joinpath(test_dir, "diff_ref.png"))
+            @test_pixelmatch joinpath(foldername, "diff") diff_between_both
+        finally
+            rm(test_dir; recursive=true, force=true)
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using PixelMatch: @test_pixelmatch_fails
 using ColorTypes
 using FileIO
 using PNGFiles
+using ReferenceTests
 
 PixelMatch.INTERACTIVE_MODE[] = false
 
@@ -150,6 +151,12 @@ end
             rec_path2 = joinpath(test_dir, "different_rec.png")
             diff_path2 = joinpath(test_dir, "different_diff.png")
             @test_pixelmatch_fails joinpath(foldername, "different") different_image 143 threshold=0.05
+
+            @test_reference joinpath(@__DIR__, "html_diff_viewer") PixelMatch.html_diff_viewer(; name = "Different", num_pixels_diff = 143, ref_path = ref_path2, rec_path = rec_path2, diff_path = diff_path2, shorten_embeds = true)
+            # whether the viewer works can only be checked manually
+            if isinteractive() && Base.displayable(MIME("juliavscode/html"))
+                display(MIME("juliavscode/html"), PixelMatch.html_diff_viewer(; name = "Different", num_pixels_diff = 143, ref_path = ref_path2, rec_path = rec_path2, diff_path = diff_path2))
+            end
             
             @test isfile(rec_path2)
             @test isfile(diff_path2)


### PR DESCRIPTION
This PR adds a `@test_pixelmatch` macro. It compares a reference png with a recording and stores a diff image if they don't match. It can also show an interactive diff viewer in VSCode which makes deciding whether to update failing references much easier:

<img width="568" height="437" alt="image" src="https://github.com/user-attachments/assets/344dd473-11cd-431e-b5c3-e47e55f526b3" />
