### PR TITLE
fix(test_macro): fail @test_pixelmatch on size mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed a bug in `@test_pixelmatch` where a size mismatch between reference and recorded images would silently pass instead of failing the test.
+
 ## 1.1.0 - 2025-12-01
 
 - Added the `@test_pixelmatch` macro which is a similar convenience macro to `@test_reference` from ReferenceTests.jl, just with a different naming scheme, the saving of diff images and displaying of a test difference viewer in VSCode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Fixed a bug in `@test_pixelmatch` where a size mismatch between reference and recorded images would silently pass instead of failing the test.
+## 1.1.1 - 2026-05-12
+
+- Fixed a bug in `@test_pixelmatch` where a size mismatch between reference and recorded images would silently pass instead of failing the test. [#4](https://github.com/jkrumbiegel/PixelMatch.jl/pull/4)
 
 ## 1.1.0 - 2025-12-01
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PixelMatch"
 uuid = "433bd86c-62cb-491d-a348-72c5c8365002"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
 
 [deps]

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -76,7 +76,7 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
                     @info "Reference size $(size(img_ref)) does not match recorded size $(size(recorded)) and JULIA_REFERENCETESTS_UPDATE=true, updating reference image"
                     PNGFiles.save(ref_path, recorded)
                 else
-                    Test.@test size(img_ref) != size(recorded)
+                    Test.@test size(img_ref) == size(recorded)
                 end
             else
                 # Compare images using PixelMatch

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
+MetaTesting = "9e32d19f-1e4f-477a-8631-b16c78aa0f56"
 PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 PixelMatch = "433bd86c-62cb-491d-a348-72c5c8365002"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using ColorTypes
 using FileIO
 using PNGFiles
 using ReferenceTests
+using MetaTesting: fails
 
 PixelMatch.INTERACTIVE_MODE[] = false
 
@@ -175,6 +176,14 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, read(p.path))
                 
                 cp(diff_path2, joinpath(test_dir, "diff_ref.png"))
                 @test_pixelmatch joinpath(foldername, "diff") diff_between_both
+
+                # Regression test: a size mismatch between reference and recorded
+                # must cause the macro's nested @test to fail.
+                cp(joinpath(@__DIR__, "fixtures", "1a.png"), joinpath(test_dir, "size_mismatch_ref.png"))
+                size_mismatch_image = fill(RGBA(0.5, 0.5, 0.5, 1.0), 5, 5)
+                @test fails() do
+                    @test_pixelmatch joinpath(foldername, "size_mismatch") size_mismatch_image
+                end
             finally
                 rm(test_dir; recursive=true, force=true)
             end


### PR DESCRIPTION
## Summary

- The size-mismatch branch in `@test_pixelmatch` asserted `size(img_ref) != size(recorded)`, which is always true at that point, so a reference/recorded size difference silently passed instead of failing the test. Flipped the assertion to `==`.
- Added a regression test using `MetaTesting.fails` (added to `test/Project.toml`) that copies a 256x512 reference and records a 5x5 image, asserting the macro registers a failure.
- Bumped the version to 1.1.1.

## Checks

- [x] Full suite passes locally with the fix applied (35/35).
- [x] Verified the regression test fails on the buggy source (reverted `==` back to `!=` to confirm).