### PR TITLE
perf: thread pixelmatch across columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.0 - 2026-05-12
+
+- `pixelmatch` is now threaded, roughly 5–7× faster on medium and large images with 10 threads available. [#6](https://github.com/jkrumbiegel/PixelMatch.jl/pull/6)
+
 ## 1.2.0 - 2026-05-12
 
 - Performance refactor of `pixelmatch`, ~2–3× faster with ~16× less allocation on the bundled test images. Also exposed a `checkerboard` keyword matching upstream pixelmatch 7.2. [#5](https://github.com/jkrumbiegel/PixelMatch.jl/pull/5)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PixelMatch"
 uuid = "433bd86c-62cb-491d-a348-72c5c8365002"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
 
 [deps]

--- a/src/PixelMatch.jl
+++ b/src/PixelMatch.jl
@@ -56,16 +56,36 @@ function pixelmatch(img1::AbstractMatrix{<:Colorant}, img2::AbstractMatrix{<:Col
 
     max_delta = 35215.0 * threshold * threshold
     alpha_f = Float64(alpha)
-    diff = 0
 
-    @inbounds for x in 1:width, y in 1:height
+    nthr = Threads.nthreads()
+    nchunks = min(nthr, width)
+    chunk_size = cld(width, nchunks)
+    chunks = collect(Iterators.partition(1:width, chunk_size))
+    diff_counts = zeros(Int, length(chunks))
+
+    @sync for ci in eachindex(chunks)
+        x_chunk = chunks[ci]
+        Threads.@spawn diff_counts[ci] = _pixelmatch_chunk!(
+            OutColor, output, img1, img2, x_chunk, height, width,
+            aa_col, diff_col, alt_col, alpha_f, max_delta,
+            include_aa, diff_mask, checkerboard)
+    end
+
+    return sum(diff_counts), output
+end
+
+function _pixelmatch_chunk!(::Type{C}, output, img1, img2, x_chunk, height, width,
+                            aa_col, diff_col, alt_col, alpha_f, max_delta,
+                            include_aa::Bool, diff_mask::Bool, checkerboard::Bool) where {C}
+    local_diff = 0
+    @inbounds for x in x_chunk, y in 1:height
         p1 = img1[y, x]
         p2 = img2[y, x]
         r1, g1, b1, a1 = rgba_bytes(p1)
 
         if p1 == p2
             if !diff_mask
-                output[y, x] = gray_pixel(OutColor, r1, g1, b1, a1, alpha_f)
+                output[y, x] = gray_pixel(C, r1, g1, b1, a1, alpha_f)
             end
             continue
         end
@@ -85,14 +105,13 @@ function pixelmatch(img1::AbstractMatrix{<:Colorant}, img2::AbstractMatrix{<:Col
                 end
             else
                 output[y, x] = delta < 0 ? alt_col : diff_col
-                diff += 1
+                local_diff += 1
             end
         elseif !diff_mask
-            output[y, x] = gray_pixel(OutColor, r1, g1, b1, a1, alpha_f)
+            output[y, x] = gray_pixel(C, r1, g1, b1, a1, alpha_f)
         end
     end
-
-    return diff, output
+    return local_diff
 end
 
 @inline function rgba_bytes(c::Colorant)


### PR DESCRIPTION
Splits the per-pixel loop into column chunks and runs each on its own task with a thread-local diff counter. Sweeping `JULIA_NUM_THREADS` on a 10-core machine, the diff-path scales near-linearly to ~4 threads and continues to gain up to 10:

| Size      | t=1   | t=2   | t=4   | t=8   | t=10  | speedup |
|-----------|-------|-------|-------|-------|-------|---------|
| 200×200   | 0.31  | 0.17  | 0.12  | 0.14  | 0.20  | 1.6×    |
| 800×800   | 5.85  | 3.31  | 1.75  | 0.98  | 0.83  | 7.0×    |
| 1600×1600 | 24.42 | 12.71 | 6.92  | 4.22  | 4.27  | 5.7×    |
| 2000×2000 | 38.28 | 20.79 | 11.15 | 7.00  | 5.69  | 6.7×    |

(min times in ms, 5% random pixel differences, RGBA{Float64})

Diff counts are bit-identical across thread counts. Bumps to 1.3.0.

## Checks

- Existing test suite passes (`include("test/runtests.jl")` → 35/35)
- Benchmark sweep across `JULIA_NUM_THREADS={1,2,4,6,8,10}` confirmed identical diff counts at every thread count