### PR TITLE
feat(test_macro): support skip and broken kwargs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.6'
+          - '1.7'
           - '1'
         os:
           - ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.4.0 - 2026-05-13
+
+- `@test_pixelmatch` accepts `skip=cond` and `broken=cond`, matching `Test.@test`. [#7](https://github.com/jkrumbiegel/PixelMatch.jl/pull/7)
+
 ## 1.3.0 - 2026-05-12
 
 - `pixelmatch` is now threaded, roughly 5–7× faster on medium and large images with 10 threads available. [#6](https://github.com/jkrumbiegel/PixelMatch.jl/pull/6)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PixelMatch"
 uuid = "433bd86c-62cb-491d-a348-72c5c8365002"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
 
 [deps]
@@ -14,4 +14,4 @@ Base64 = "1"
 ColorTypes = "0.12"
 PNGFiles = "0.4"
 Test = "1"
-julia = "1.6"
+julia = "1.7"

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -9,21 +9,32 @@ Files created:
 - `name_rec.png` - recorded/actual image (when test runs)
 - `name_diff.png` - diff image (when images differ)
 
-If the reference doesn't exist, it will be created. If images differ, an 
-interactive HTML diff viewer is shown (when available in VSCode) and the 
+If the reference doesn't exist, it will be created. If images differ, an
+interactive HTML diff viewer is shown (when available in VSCode) and the
 user is prompted to update the reference.
 
 Use `JULIA_REFERENCETESTS_UPDATE=true` to force-update all references without prompting.
 
+Supports the same `skip=cond` and `broken=cond` keyword arguments as `Test.@test`:
+- `skip=true` does not evaluate `image` and records a skipped test.
+- `broken=true` expects the image to differ from the reference; if it actually
+  matches, the test is recorded as an unexpected pass (`Error`).
+
 # Example
 ```julia
 @test_pixelmatch "references/my_plot" render(fig)
+@test_pixelmatch "references/wip"     render(fig) broken=true
+@test_pixelmatch "references/slow"    render(fig) skip=Sys.iswindows()
 ```
 """
 macro test_pixelmatch(name, expr, kwargs...)
     dir = Base.source_dir()
+    skip_ex, broken_ex, other_kws = _extract_skip_broken(kwargs)
     quote
-        _test_pixelmatch(abspath(joinpath($dir, $(esc(name)))), $(esc(expr)); $(esc.(kwargs)...))
+        _test_pixelmatch_dispatch(abspath(joinpath($dir, $(esc(name)))), $(esc(:(() -> $expr)));
+            skip = $(esc(skip_ex)),
+            broken = $(esc(broken_ex)),
+            $(map(esc, other_kws)...))
     end
 end
 
@@ -35,7 +46,37 @@ macro test_pixelmatch_fails(name, expr, numpixels, kwargs...)
     end
 end
 
-function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch::Union{Integer,Nothing} = nothing, kwargs...)
+function _extract_skip_broken(kwargs)
+    skip_ex = false
+    broken_ex = false
+    other = Any[]
+    for kw in kwargs
+        if kw isa Expr && kw.head === :(=) && kw.args[1] === :skip
+            skip_ex = kw.args[2]
+        elseif kw isa Expr && kw.head === :(=) && kw.args[1] === :broken
+            broken_ex = kw.args[2]
+        else
+            push!(other, kw)
+        end
+    end
+    return skip_ex, broken_ex, other
+end
+
+function _test_pixelmatch_dispatch(path_stem::String, render; skip::Bool = false, broken::Bool = false, kwargs...)
+    if skip && broken
+        error("invalid @test_pixelmatch call: cannot set both skip and broken keywords")
+    end
+    name = basename(path_stem)
+    if skip
+        Test.@testset "$name" begin
+            Test.@test true skip=true
+        end
+        return
+    end
+    _test_pixelmatch(path_stem, render(); broken, kwargs...)
+end
+
+function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch::Union{Integer,Nothing} = nothing, broken::Bool = false, kwargs...)
     update = tryparse(Bool, get(ENV, "JULIA_REFERENCETESTS_UPDATE", "false")) === true
     
     ref_path = path_stem * "_ref.png"
@@ -76,7 +117,7 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
                     @info "Reference size $(size(img_ref)) does not match recorded size $(size(recorded)) and JULIA_REFERENCETESTS_UPDATE=true, updating reference image"
                     PNGFiles.save(ref_path, recorded)
                 else
-                    Test.@test size(img_ref) == size(recorded)
+                    Test.@test size(img_ref) == size(recorded) broken=broken
                 end
             else
                 # Compare images using PixelMatch
@@ -84,24 +125,26 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
 
                 if test_pixel_mismatch !== nothing
                     test_pixel_mismatch <= 0 && error("The number of expected mismatching pixels must be larger than zero, was $test_pixel_mismatch")
-                    Test.@test test_pixel_mismatch == num_pixels_diff
+                    Test.@test test_pixel_mismatch == num_pixels_diff broken=broken
                     PNGFiles.save(diff_path, diff_image)
                 else
                     if num_pixels_diff > 0
                         # Save diff image
                         PNGFiles.save(diff_path, diff_image)
 
-                        # Print paths for inspection
-                        println("Reference test failed: $name")
-                        println("  Reference: $ref_path")
-                        println("  Recorded:    $rec_path")
-                        println("  Diff:      $diff_path")
-                        println("  Pixels different: $num_pixels_diff")
+                        if !broken
+                            # Print paths for inspection
+                            println("Reference test failed: $name")
+                            println("  Reference: $ref_path")
+                            println("  Recorded:    $rec_path")
+                            println("  Diff:      $diff_path")
+                            println("  Pixels different: $num_pixels_diff")
+                        end
 
                         if update
                             @info "JULIA_REFERENCETESTS_UPDATE=true, updating reference image"
                             cp(rec_path, ref_path; force = true)
-                        elseif interactive
+                        elseif interactive && !broken
                             # Display HTML diff viewer if available
                             if Base.displayable(MIME("juliavscode/html"))
                                 display(MIME("juliavscode/html"), html_diff_viewer(; name, num_pixels_diff, ref_path, rec_path, diff_path))
@@ -115,10 +158,10 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
                                 Test.@test num_pixels_diff == 0
                             end
                         else
-                            Test.@test num_pixels_diff == 0
+                            Test.@test num_pixels_diff == 0 broken=broken
                         end
                     else
-                        Test.@test num_pixels_diff == 0
+                        Test.@test num_pixels_diff == 0 broken=broken
                     end
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using ColorTypes
 using FileIO
 using PNGFiles
 using ReferenceTests
-using MetaTesting: fails
+using MetaTesting: fails, nonpassing_results
 
 PixelMatch.INTERACTIVE_MODE[] = false
 
@@ -183,6 +183,62 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, read(p.path))
                 size_mismatch_image = fill(RGBA(0.5, 0.5, 0.5, 1.0), 5, 5)
                 @test fails() do
                     @test_pixelmatch joinpath(foldername, "size_mismatch") size_mismatch_image
+                end
+
+                @testset "skip keyword" begin
+                    # skip=true must not evaluate the image expression, must not write
+                    # files, must not fail even when no reference exists, and must
+                    # record a single Broken(:skipped) result.
+                    rendered = Ref(false)
+                    render_with_flag() = (rendered[] = true; test_image)
+                    results = nonpassing_results() do
+                        @test_pixelmatch joinpath(foldername, "skipped") render_with_flag() skip=true
+                    end
+                    @test rendered[] == false
+                    @test !isfile(joinpath(test_dir, "skipped_rec.png"))
+                    @test !isfile(joinpath(test_dir, "skipped_ref.png"))
+                    broken_results = filter(r -> r isa Test.Broken, results)
+                    @test length(broken_results) == 1
+                    @test broken_results[1].test_type == :skipped
+
+                    # skip=false must behave as if the keyword was absent.
+                    cp(joinpath(@__DIR__, "fixtures", "1a.png"), joinpath(test_dir, "not_skipped_ref.png"))
+                    @test_pixelmatch joinpath(foldername, "not_skipped") test_image skip=false
+                    @test isfile(joinpath(test_dir, "not_skipped_rec.png"))
+                end
+
+                @testset "broken keyword" begin
+                    # broken=true on a mismatching image must record Broken(:test)
+                    # and must not fail the surrounding testset.
+                    cp(joinpath(@__DIR__, "fixtures", "1a.png"), joinpath(test_dir, "broken_mismatch_ref.png"))
+                    results = nonpassing_results() do
+                        @test_pixelmatch joinpath(foldername, "broken_mismatch") different_image broken=true threshold=0.05
+                    end
+                    @test count(r -> r isa Test.Fail, results) == 0
+                    @test count(r -> r isa Test.Error, results) == 0
+                    broken_results = filter(r -> r isa Test.Broken, results)
+                    @test length(broken_results) == 1
+                    @test broken_results[1].test_type == :test
+
+                    # broken=true on a matching image is an unexpected pass and must
+                    # be recorded as Test.Error(:test_unbroken).
+                    cp(joinpath(@__DIR__, "fixtures", "1a.png"), joinpath(test_dir, "broken_match_ref.png"))
+                    results = nonpassing_results() do
+                        @test_pixelmatch joinpath(foldername, "broken_match") test_image broken=true
+                    end
+                    error_results = filter(r -> r isa Test.Error, results)
+                    @test length(error_results) == 1
+                    @test error_results[1].test_type == :test_unbroken
+
+                    # broken=false must behave as if the keyword was absent.
+                    cp(joinpath(@__DIR__, "fixtures", "1a.png"), joinpath(test_dir, "broken_false_ref.png"))
+                    @test_pixelmatch joinpath(foldername, "broken_false") test_image broken=false
+                end
+
+                @testset "skip and broken together is an error" begin
+                    @test_throws "cannot set both skip and broken" begin
+                        @test_pixelmatch joinpath(foldername, "skip_and_broken") test_image skip=true broken=true
+                    end
                 end
             finally
                 rm(test_dir; recursive=true, force=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,21 @@ using MetaTesting: fails, nonpassing_results
 
 PixelMatch.INTERACTIVE_MODE[] = false
 
+# This can be removed for `@test_throws` once CI only uses Julia 1.8 and up
+macro test_throws_message(message::String, exp)
+    return quote
+        threw_exception = false
+        try
+            $(esc(exp))
+        catch e
+            msg = sprint(Base.showerror, e)
+            threw_exception = true
+            @test occursin($message, msg)
+        end
+        @test threw_exception
+    end
+end
+
 # Helper function to read PNG images
 function read_image(name::String)
     filepath = joinpath(@__DIR__, "fixtures", "$name.png")
@@ -236,7 +251,7 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, read(p.path))
                 end
 
                 @testset "skip and broken together is an error" begin
-                    @test_throws "cannot set both skip and broken" begin
+                    @test_throws_message "cannot set both skip and broken" begin
                         @test_pixelmatch joinpath(foldername, "skip_and_broken") test_image skip=true broken=true
                     end
                 end


### PR DESCRIPTION
## Summary

- `@test_pixelmatch` now accepts `skip=cond` and `broken=cond`, matching the semantics of `Test.@test`.
- `skip=true` skips rendering and records a `Broken(:skipped)` result; `broken=true` marks the comparison as `Broken` when it differs and as `Error` when it unexpectedly matches.
- Julia compat bumped from 1.6 to 1.7 (`@test` got these kwargs in 1.7)