### PR TITLE
feat(report): add @pixelmatch_report for CI failure galleries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,3 +39,12 @@ jobs:
       - uses: julia-actions/cache@d10a6fd8f31b12404a54613ebad242900567f2b9 # v2.1.0
       - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
       - uses: julia-actions/julia-runtest@678da69444cd5f13d7e674a90cb4f534639a14f9 # v1.11.2
+      # The test suite generates an example report from deliberate failures via
+      # @pixelmatch_report; upload it so the artifact workflow can be inspected here.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.version == '1'
+        with:
+          name: pixelmatch-report
+          path: test/pixelmatch-report.html
+          archive: false
+          if-no-files-found: ignore

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,4 +47,4 @@ jobs:
           name: pixelmatch-report
           path: test/pixelmatch-report.html
           archive: false
-          if-no-files-found: ignore
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+test/pixelmatch-report.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `@pixelmatch_report`, which wraps a block of `@test_pixelmatch` calls and writes a self-contained HTML report of all failing comparisons for CI artifact upload. [#8](https://github.com/jkrumbiegel/PixelMatch.jl/pull/8)
+
 ## 1.4.0 - 2026-05-13
 
 - `@test_pixelmatch` accepts `skip=cond` and `broken=cond`, matching `Test.@test`. [#7](https://github.com/jkrumbiegel/PixelMatch.jl/pull/7)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PixelMatch"
 uuid = "433bd86c-62cb-491d-a348-72c5c8365002"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ end
 
 Unlike globbing for `*_diff.png`, this captures every failure mode, including size mismatches and missing references, which produce no diff image. The report is only written when there is at least one failure.
 
-The report is a single HTML file with all CSS, JavaScript and images inlined, so it works as an unzipped GitHub Actions artifact (`actions/upload-artifact@v7` or later with `archive: false`) that the browser can open directly:
+The report is a single HTML file with all CSS, JavaScript and images inlined, so it works as an unzipped GitHub Actions artifact (`actions/upload-artifact@v7` or later with `archive: false`) that the browser can open directly. `if-no-files-found: ignore` keeps the step quiet when tests fail for a reason unrelated to reference images, in which case no report is written:
 
 ```yaml
       - uses: julia-actions/julia-runtest@v1
@@ -64,4 +64,5 @@ The report is a single HTML file with all CSS, JavaScript and images inlined, so
           name: pixelmatch-report
           path: test/pixelmatch-report.html
           archive: false
+          if-no-files-found: ignore
 ```

--- a/README.md
+++ b/README.md
@@ -32,3 +32,36 @@ It takes a path (without extension) relative to the place where it's called and 
 ```
 
 Three files are written, `folder/name_rec.png`, `folder/name_ref.png` and if there's a difference, `folder/name_diff.png`. Both `*_rec.png` and `*_diff.png` should be added to `.gitignore`.
+
+## CI failure reports
+
+When reference tests fail on CI, it's useful to download the offending images and inspect them. Wrap your `@test_pixelmatch` calls in `@pixelmatch_report` and it writes a single self-contained HTML file with every failing comparison, embedding the reference, recorded and diff images so you can toggle between them:
+
+```julia
+PixelMatch.@pixelmatch_report out_file=joinpath(@__DIR__, "pixelmatch-report.html") begin
+    @test_pixelmatch "references/plot_a" render(fig_a)
+    @test_pixelmatch "references/plot_b" render(fig_b)
+end
+```
+
+The block always executes. Pass `enabled=false` to skip report generation, gating it on whatever condition you like, e.g. only on CI:
+
+```julia
+PixelMatch.@pixelmatch_report enabled=get(ENV, "CI", "false") == "true" out_file=joinpath(@__DIR__, "pixelmatch-report.html") begin
+    @test_pixelmatch "references/plot_a" render(fig_a)
+end
+```
+
+Unlike globbing for `*_diff.png`, this captures every failure mode, including size mismatches and missing references, which produce no diff image. The report is only written when there is at least one failure.
+
+The report is a single HTML file with all CSS, JavaScript and images inlined, so it works as an unzipped GitHub Actions artifact (`actions/upload-artifact@v7` or later with `archive: false`) that the browser can open directly:
+
+```yaml
+      - uses: julia-actions/julia-runtest@v1
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: pixelmatch-report
+          path: test/pixelmatch-report.html
+          archive: false
+```

--- a/src/PixelMatch.jl
+++ b/src/PixelMatch.jl
@@ -9,6 +9,7 @@ INTERACTIVE_MODE = Ref(true)
 
 export @test_pixelmatch
 export pixelmatch
+export @pixelmatch_report
 
 """
     pixelmatch(img1, img2; threshold=0.1, include_aa=false,
@@ -257,5 +258,6 @@ diff output is bit-identical to the reference implementation.
 end
 
 include("test_macro.jl")
+include("report.jl")
 
 end # module PixelMatch

--- a/src/report.jl
+++ b/src/report.jl
@@ -1,0 +1,216 @@
+struct FailureRecord
+    name::String
+    status::Symbol
+    num_pixels_diff::Union{Int,Nothing}
+    ref_path::Union{String,Nothing}
+    rec_path::Union{String,Nothing}
+    diff_path::Union{String,Nothing}
+    ref_size::Union{Tuple{Int,Int},Nothing}
+    rec_size::Union{Tuple{Int,Int},Nothing}
+end
+
+mutable struct Collector
+    lock::ReentrantLock
+    records::Vector{FailureRecord}
+end
+
+const ACTIVE_COLLECTOR = Ref{Union{Nothing,Collector}}(nothing)
+
+function _record_failure(; name, status, num_pixels_diff=nothing,
+                         ref_path=nothing, rec_path=nothing, diff_path=nothing,
+                         ref_size=nothing, rec_size=nothing)
+    c = ACTIVE_COLLECTOR[]
+    c === nothing && return
+    exists(p) = p !== nothing && isfile(p) ? p : nothing
+    rec = FailureRecord(name, status, num_pixels_diff,
+                        exists(ref_path), exists(rec_path), exists(diff_path),
+                        ref_size, rec_size)
+    lock(c.lock) do
+        push!(c.records, rec)
+    end
+    return
+end
+
+"""
+    @pixelmatch_report [enabled=true] [out_file="pixelmatch-report.html"] begin
+        ...
+    end
+
+Run the given block (typically containing `@test_pixelmatch` calls) and, if any of those
+tests fail, write a self-contained HTML report of the failing comparisons to `out_file`.
+
+The report embeds the reference, recorded and (where available) diff images so the file
+can be opened on its own. It captures every failure mode, including size mismatches and
+missing references, which produce no diff image.
+
+When `enabled` is false, the block runs unchanged and no report is written. Gate `enabled`
+on whatever condition you like, e.g. only generate the report on CI:
+
+    @pixelmatch_report enabled=get(ENV, "CI", "false") == "true" begin ... end
+
+Generation happens in the same process that runs the tests, so PixelMatch does not need
+to be loadable from a separate step. Being a macro, it wraps the block in a `try`/`finally`
+in place, adding no closure or stack frame. Calls to `@test_pixelmatch` outside an active
+`@pixelmatch_report` block record nothing and behave exactly as before.
+
+Evaluates to whatever the block evaluates to.
+
+# Example
+```julia
+PixelMatch.@pixelmatch_report out_file=joinpath(@__DIR__, "pixelmatch-report.html") begin
+    @test_pixelmatch "references/plot_a" render(fig_a)
+    @test_pixelmatch "references/plot_b" render(fig_b)
+end
+```
+"""
+macro pixelmatch_report(args...)
+    isempty(args) && error("@pixelmatch_report requires a block to run")
+    body = last(args)
+    enabled = true
+    out_file = "pixelmatch-report.html"
+    for kw in args[1:end-1]
+        (kw isa Expr && kw.head === :(=)) ||
+            error("@pixelmatch_report expects keyword arguments before the block, got $kw")
+        key, val = kw.args[1], kw.args[2]
+        if key === :enabled
+            enabled = val
+        elseif key === :out_file
+            out_file = val
+        else
+            error("unknown keyword `$key` for @pixelmatch_report")
+        end
+    end
+    quote
+        local active = $(esc(enabled)) && ACTIVE_COLLECTOR[] === nothing
+        local outfile = $(esc(out_file))
+        local collector = active ? Collector(ReentrantLock(), FailureRecord[]) : nothing
+        active && (ACTIVE_COLLECTOR[] = collector)
+        try
+            $(esc(body))
+        finally
+            if active
+                ACTIVE_COLLECTOR[] = nothing
+                if !isempty(collector.records)
+                    write_report(outfile, collector.records)
+                    @info "PixelMatch wrote a report of $(length(collector.records)) failing reference test(s) to $(abspath(outfile))"
+                end
+            end
+        end
+    end
+end
+
+const _REPORT_TEMPLATE = read(joinpath(@__DIR__, "report_template.html"), String)
+
+write_report(path::AbstractString, records::AbstractVector{FailureRecord}) =
+    open(io -> print(io, report_html(records)), path, "w")
+
+function report_html(records::AbstractVector{FailureRecord})
+    n = length(records)
+    cards = IOBuffer()
+    for r in records
+        _print_card(cards, r)
+    end
+    return replace(_REPORT_TEMPLATE,
+        "{{SUMMARY}}" => "$n failing reference test$(n == 1 ? "" : "s")",
+        "{{CARDS}}" => String(take!(cards)))
+end
+
+function _print_card(io::IO, r::FailureRecord)
+    statustext =
+        r.status === :mismatch ? "$(r.num_pixels_diff) pixel$(r.num_pixels_diff == 1 ? "" : "s") differ" :
+        r.status === :size_mismatch ? "size mismatch: reference $(_sz(r.ref_size)), recorded $(_sz(r.rec_size))" :
+        "missing reference"
+
+    has_ref = r.ref_path !== nothing
+    has_rec = r.rec_path !== nothing
+    has_diff = r.diff_path !== nothing
+    default = has_diff ? "diff" : (has_rec ? "rec" : "ref")
+
+    ref_dim = has_ref ? _png_display_size(r.ref_path) : nothing
+    rec_dim = has_rec ? _png_display_size(r.rec_path) : nothing
+    diff_dim = ref_dim !== nothing ? ref_dim : rec_dim
+
+    print(io, """<section class="card">
+<div class="card-head"><span class="name">$(_html_escape(r.name))</span><span class="status status-$(r.status)">$(_html_escape(statustext))</span></div>
+<div class="controls">""")
+    if has_ref && has_rec
+        print(io, """<button type="button" data-role="toggle"$(has_diff ? "" : " class=\"active\"")>Showing Recorded</button>""")
+    elseif has_rec
+        print(io, """<button type="button" disabled>Recorded</button>""")
+    elseif has_ref
+        print(io, """<button type="button" disabled>Reference</button>""")
+    end
+    has_diff && print(io, """<button type="button" data-role="diff" class="active">Diff</button>""")
+    print(io, """</div>
+<div class="stage">""")
+    has_ref && print(io, _img("ref", r.ref_path, default, ref_dim))
+    has_rec && print(io, _img("rec", r.rec_path, default, rec_dim))
+    has_diff && print(io, _img("diff", r.diff_path, default, diff_dim))
+    print(io, """</div>
+</section>
+""")
+end
+
+function _img(view, path, default, dim)
+    sizeattr = dim === nothing ? "" : " width=\"$(dim[1])\" height=\"$(dim[2])\""
+    return """<img class="img-$view" data-view="$view" alt="$view"$sizeattr style="display:$(view == default ? "block" : "none")" src="$(_img_src(path))">"""
+end
+
+_img_src(path) = "data:image/png;base64," * Base64.base64encode(read(path))
+
+const _PNG_SIGNATURE = UInt8[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+
+_beuint(b, i) = (UInt32(b[i]) << 24) | (UInt32(b[i+1]) << 16) | (UInt32(b[i+2]) << 8) | UInt32(b[i+3])
+
+"""
+Display size of a PNG in CSS pixels, honoring the `pHYs` chunk so images saved at a
+higher pixel density (e.g. 2× HiDPI renders) appear at their intended physical size.
+Returns `(width, height)`, falling back to the raw pixel dimensions when no usable
+`pHYs` information is present, or `nothing` if the file is not a parseable PNG.
+"""
+function _png_display_size(path)
+    bytes = read(path)
+    n = length(bytes)
+    (n < 8 || @view(bytes[1:8]) != _PNG_SIGNATURE) && return nothing
+
+    pxw = pxh = 0
+    ppux = ppuy = 0
+    unit = 0x00
+    seen_ihdr = false
+    pos = 9
+    while pos + 7 <= n
+        len = Int(_beuint(bytes, pos))
+        data0 = pos + 8
+        ctype = String(@view bytes[pos+4:pos+7])
+        if ctype == "IHDR" && data0 + 7 <= n
+            pxw = Int(_beuint(bytes, data0))
+            pxh = Int(_beuint(bytes, data0 + 4))
+            seen_ihdr = true
+        elseif ctype == "pHYs" && data0 + 8 <= n
+            ppux = Int(_beuint(bytes, data0))
+            ppuy = Int(_beuint(bytes, data0 + 4))
+            unit = bytes[data0 + 8]
+            break
+        elseif ctype == "IEND"
+            break
+        end
+        pos = data0 + len + 4
+    end
+    seen_ihdr || return nothing
+
+    if unit == 0x01 && ppux > 0 && ppuy > 0
+        return (max(round(Int, pxw * 96 / (ppux * 0.0254)), 1),
+                max(round(Int, pxh * 96 / (ppuy * 0.0254)), 1))
+    end
+    return (pxw, pxh)
+end
+
+_sz(t) = t === nothing ? "?" : "$(t[1])×$(t[2])"
+
+function _html_escape(s)
+    s = replace(string(s), "&" => "&amp;")
+    s = replace(s, "<" => "&lt;")
+    s = replace(s, ">" => "&gt;")
+    s = replace(s, "\"" => "&quot;")
+    return s
+end

--- a/src/report_template.html
+++ b/src/report_template.html
@@ -10,8 +10,8 @@ body { font-family: -apple-system, system-ui, Segoe UI, Arial, sans-serif; margi
 header { padding: 16px 24px; border-bottom: 1px solid #30363d; }
 header h1 { margin: 0 0 4px; font-size: 18px; }
 header p { margin: 0; color: #8b949e; }
-.gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 16px; padding: 24px; }
-.card { border: 1px solid #30363d; border-radius: 8px; background: #161b22; overflow: hidden; display: flex; flex-direction: column; }
+.gallery { display: flex; flex-wrap: wrap; align-items: flex-start; gap: 16px; padding: 24px; }
+.card { border: 1px solid #30363d; border-radius: 8px; background: #161b22; overflow: hidden; display: flex; flex-direction: column; min-width: 0; max-width: 100%; }
 .card-head { display: flex; flex-direction: column; gap: 2px; padding: 10px 12px; border-bottom: 1px solid #30363d; }
 .name { font-weight: 600; overflow-wrap: anywhere; }
 .status { color: #8b949e; font-size: 12px; overflow-wrap: anywhere; }
@@ -20,8 +20,8 @@ header p { margin: 0; color: #8b949e; }
 .controls { display: flex; gap: 6px; padding: 8px 12px; }
 .controls button { flex: 1; padding: 6px 10px; border: 1px solid #30363d; border-radius: 6px; background: #21262d; color: #e6edf3; cursor: pointer; font-size: 13px; }
 .controls button.active { background: #1f6feb; border-color: #1f6feb; color: #fff; }
-.stage { background: #010409; padding: 8px; display: flex; justify-content: safe center; overflow: auto; max-height: 80vh; cursor: pointer; }
-.stage img { display: block; }
+.stage { background: #010409; padding: 8px; display: flex; justify-content: center; cursor: pointer; }
+.stage img { max-width: 100%; height: auto; display: block; }
 </style>
 </head>
 <body>

--- a/src/report_template.html
+++ b/src/report_template.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PixelMatch reference test failures</title>
+<style>
+* { box-sizing: border-box; }
+body { font-family: -apple-system, system-ui, Segoe UI, Arial, sans-serif; margin: 0; background: #0d1117; color: #e6edf3; }
+header { padding: 16px 24px; border-bottom: 1px solid #30363d; }
+header h1 { margin: 0 0 4px; font-size: 18px; }
+header p { margin: 0; color: #8b949e; }
+.gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 16px; padding: 24px; }
+.card { border: 1px solid #30363d; border-radius: 8px; background: #161b22; overflow: hidden; display: flex; flex-direction: column; }
+.card-head { display: flex; flex-direction: column; gap: 2px; padding: 10px 12px; border-bottom: 1px solid #30363d; }
+.name { font-weight: 600; overflow-wrap: anywhere; }
+.status { color: #8b949e; font-size: 12px; overflow-wrap: anywhere; }
+.status-mismatch { color: #f85149; }
+.status-size_mismatch, .status-missing_ref { color: #d29922; }
+.controls { display: flex; gap: 6px; padding: 8px 12px; }
+.controls button { flex: 1; padding: 6px 10px; border: 1px solid #30363d; border-radius: 6px; background: #21262d; color: #e6edf3; cursor: pointer; font-size: 13px; }
+.controls button.active { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+.stage { background: #010409; padding: 8px; display: flex; justify-content: center; cursor: pointer; }
+.stage img { max-width: 100%; height: auto; }
+</style>
+</head>
+<body>
+<header>
+<h1>PixelMatch reference test failures</h1>
+<p>{{SUMMARY}}</p>
+</header>
+<main class="gallery">
+{{CARDS}}</main>
+<script>
+document.querySelectorAll('.card').forEach(function (card) {
+  var toggle = card.querySelector('button[data-role="toggle"]');
+  var diffBtn = card.querySelector('button[data-role="diff"]');
+  var imgs = {
+    ref: card.querySelector('img[data-view="ref"]'),
+    rec: card.querySelector('img[data-view="rec"]'),
+    diff: card.querySelector('img[data-view="diff"]'),
+  };
+  var pair = imgs.rec ? 'rec' : 'ref';
+  var showingDiff = !!imgs.diff;
+
+  function render() {
+    var view = showingDiff ? 'diff' : pair;
+    Object.keys(imgs).forEach(function (k) { if (imgs[k]) imgs[k].style.display = k === view ? 'block' : 'none'; });
+    if (toggle) {
+      toggle.textContent = pair === 'rec' ? 'Showing Recorded' : 'Showing Reference';
+      toggle.classList.toggle('active', !showingDiff);
+    }
+    if (diffBtn) diffBtn.classList.toggle('active', showingDiff);
+  }
+
+  function flip() {
+    if (showingDiff) { showingDiff = false; }
+    else if (imgs.ref && imgs.rec) { pair = pair === 'rec' ? 'ref' : 'rec'; }
+    render();
+  }
+
+  if (toggle) toggle.addEventListener('click', flip);
+  if (diffBtn) diffBtn.addEventListener('click', function () { showingDiff = true; render(); });
+  var stage = card.querySelector('.stage');
+  if (stage) stage.addEventListener('click', flip);
+  render();
+});
+</script>
+</body>
+</html>

--- a/src/report_template.html
+++ b/src/report_template.html
@@ -20,8 +20,8 @@ header p { margin: 0; color: #8b949e; }
 .controls { display: flex; gap: 6px; padding: 8px 12px; }
 .controls button { flex: 1; padding: 6px 10px; border: 1px solid #30363d; border-radius: 6px; background: #21262d; color: #e6edf3; cursor: pointer; font-size: 13px; }
 .controls button.active { background: #1f6feb; border-color: #1f6feb; color: #fff; }
-.stage { background: #010409; padding: 8px; display: flex; justify-content: center; cursor: pointer; }
-.stage img { max-width: 100%; height: auto; }
+.stage { background: #010409; padding: 8px; display: flex; justify-content: safe center; overflow: auto; max-height: 80vh; cursor: pointer; }
+.stage img { display: block; }
 </style>
 </head>
 <body>

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -107,6 +107,7 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
                 cp(rec_path, ref_path; force = true)
             else
                 Test.@test reference_exists
+                _record_failure(; name, status = :missing_ref, rec_path, rec_size = size(recorded))
             end
         else
             # Load reference image
@@ -118,6 +119,8 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
                     PNGFiles.save(ref_path, recorded)
                 else
                     Test.@test size(img_ref) == size(recorded) broken=broken
+                    broken || _record_failure(; name, status = :size_mismatch, ref_path, rec_path,
+                        ref_size = size(img_ref), rec_size = size(recorded))
                 end
             else
                 # Compare images using PixelMatch
@@ -159,6 +162,9 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
                             end
                         else
                             Test.@test num_pixels_diff == 0 broken=broken
+                            broken || _record_failure(; name, status = :mismatch, num_pixels_diff,
+                                ref_path, rec_path, diff_path,
+                                ref_size = size(img_ref), rec_size = size(recorded))
                         end
                     else
                         Test.@test num_pixels_diff == 0 broken=broken

--- a/test/report_tests.jl
+++ b/test/report_tests.jl
@@ -120,16 +120,20 @@ end
     @testset "pixelmatch_report end-to-end" begin
         dir = mktempdir()
 
-        out = joinpath(dir, "report.html")
-        stem = joinpath(dir, "case")
-        cp(joinpath(_FIX, "1a.png"), stem * "_ref.png")
-        @pixelmatch_report enabled = true out_file = out begin
-            @test fails() do
-                @test_pixelmatch stem _img("1b") threshold = 0.05
+        report = joinpath(@__DIR__, "pixelmatch-report.html")
+        cp(joinpath(_FIX, "1a.png"), joinpath(dir, "scatter_ref.png"))
+        cp(joinpath(_FIX, "1a.png"), joinpath(dir, "resized_ref.png"))
+        @test fails() do
+            @pixelmatch_report enabled = true out_file = report begin
+                @test_pixelmatch joinpath(dir, "scatter") _img("1b") threshold = 0.05
+                @test_pixelmatch joinpath(dir, "resized") fill(RGBA(0.6, 0.6, 0.7, 1.0), 120, 200)
+                @test_pixelmatch joinpath(dir, "brand_new") _img("3a")
             end
         end
-        @test isfile(out)
-        @test occursin("data:image/png;base64,", read(out, String))
+        @test isfile(report)
+        html = read(report, String)
+        @test occursin("data:image/png;base64,", html)
+        @test _count(r"<section class=\"card\"", html) == 3
 
         out_pass = joinpath(dir, "report_pass.html")
         pass_stem = joinpath(dir, "passing")
@@ -142,8 +146,8 @@ end
         out_disabled = joinpath(dir, "report_disabled.html")
         dis_stem = joinpath(dir, "disabled")
         cp(joinpath(_FIX, "1a.png"), dis_stem * "_ref.png")
-        @pixelmatch_report enabled = false out_file = out_disabled begin
-            @test fails() do
+        @test fails() do
+            @pixelmatch_report enabled = false out_file = out_disabled begin
                 @test_pixelmatch dis_stem _img("1b") threshold = 0.05
             end
         end

--- a/test/report_tests.jl
+++ b/test/report_tests.jl
@@ -1,0 +1,157 @@
+using Test
+using PixelMatch
+using PixelMatch: FailureRecord, Collector, ACTIVE_COLLECTOR, report_html, @pixelmatch_report, _png_display_size
+using ColorTypes
+using PNGFiles
+using MetaTesting: fails, nonpassing_results
+
+PixelMatch.INTERACTIVE_MODE[] = false
+
+const _FIX = joinpath(@__DIR__, "fixtures")
+_img(name) = PNGFiles.load(joinpath(_FIX, "$name.png"))
+_count(pat, s) = length(collect(eachmatch(pat, s)))
+
+function _synthetic_png(w, h; ppm=nothing)
+    io = IOBuffer()
+    be(x) = write(io, UInt8[(x >> 24) & 0xff, (x >> 16) & 0xff, (x >> 8) & 0xff, x & 0xff])
+    write(io, UInt8[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    be(13); write(io, codeunits("IHDR")); be(w); be(h); write(io, UInt8[8, 6, 0, 0, 0]); be(0)
+    if ppm !== nothing
+        be(9); write(io, codeunits("pHYs")); be(ppm); be(ppm); write(io, UInt8[1]); be(0)
+    end
+    be(0); write(io, codeunits("IEND")); be(0)
+    path = tempname() * ".png"
+    write(path, take!(io))
+    return path
+end
+
+@testset "report" begin
+    @testset "png display size" begin
+        @test _png_display_size(joinpath(_FIX, "1a.png")) == (512, 256)
+        @test _png_display_size(_synthetic_png(200, 100)) == (200, 100)
+        @test _png_display_size(_synthetic_png(200, 100; ppm=7559)) == (100, 50)
+        notpng = tempname() * ".png"; write(notpng, "not a png")
+        @test _png_display_size(notpng) === nothing
+    end
+
+    @testset "failure recording" begin
+        dir = mktempdir()
+        c = Collector(ReentrantLock(), FailureRecord[])
+        ACTIVE_COLLECTOR[] = c
+        try
+            mismatch_stem = joinpath(dir, "mismatch")
+            cp(joinpath(_FIX, "1a.png"), mismatch_stem * "_ref.png")
+            @test fails() do
+                @test_pixelmatch mismatch_stem _img("1b") threshold = 0.05
+            end
+
+            size_stem = joinpath(dir, "sizemismatch")
+            cp(joinpath(_FIX, "1a.png"), size_stem * "_ref.png")
+            small = fill(RGBA(0.5, 0.5, 0.5, 1.0), 5, 5)
+            @test fails() do
+                @test_pixelmatch size_stem small
+            end
+
+            missing_stem = joinpath(dir, "missingref")
+            @test fails() do
+                @test_pixelmatch missing_stem _img("1a")
+            end
+
+            broken_stem = joinpath(dir, "brokencase")
+            cp(joinpath(_FIX, "1a.png"), broken_stem * "_ref.png")
+            nonpassing_results() do
+                @test_pixelmatch broken_stem _img("1b") broken = true threshold = 0.05
+            end
+
+            pass_stem = joinpath(dir, "passcase")
+            cp(joinpath(_FIX, "1a.png"), pass_stem * "_ref.png")
+            @test_pixelmatch pass_stem _img("1a")
+        finally
+            ACTIVE_COLLECTOR[] = nothing
+        end
+
+        @test length(c.records) == 3
+        byname = Dict(r.name => r for r in c.records)
+
+        m = byname["mismatch"]
+        @test m.status == :mismatch
+        @test m.num_pixels_diff > 0
+        @test m.diff_path !== nothing && isfile(m.diff_path)
+        @test m.ref_path !== nothing && m.rec_path !== nothing
+
+        s = byname["sizemismatch"]
+        @test s.status == :size_mismatch
+        @test s.diff_path === nothing
+        @test s.rec_size == (5, 5)
+        @test s.ref_size !== nothing && s.ref_size != (5, 5)
+
+        mr = byname["missingref"]
+        @test mr.status == :missing_ref
+        @test mr.ref_path === nothing
+        @test mr.rec_path !== nothing && isfile(mr.rec_path)
+        @test mr.rec_size !== nothing
+    end
+
+    @testset "report_html structure" begin
+        recs = [
+            FailureRecord("alpha", :mismatch, 143,
+                joinpath(_FIX, "1a.png"), joinpath(_FIX, "1b.png"), joinpath(_FIX, "1diff.png"),
+                (200, 256), (200, 256)),
+            FailureRecord("beta", :size_mismatch, nothing,
+                joinpath(_FIX, "1a.png"), joinpath(_FIX, "2a.png"), nothing,
+                (200, 256), (100, 100)),
+            FailureRecord("gamma", :missing_ref, nothing,
+                nothing, joinpath(_FIX, "1a.png"), nothing,
+                nothing, (200, 256)),
+        ]
+        html = report_html(recs)
+
+        @test occursin("alpha", html)
+        @test occursin("beta", html)
+        @test occursin("gamma", html)
+        @test occursin("data:image/png;base64,", html)
+
+        @test _count(r"<section class=\"card\"", html) == 3
+        @test _count(r"<button type=\"button\" data-role=\"toggle\"", html) == 2
+        @test _count(r"<button type=\"button\" data-role=\"diff\"", html) == 1
+        @test _count(r"<button type=\"button\" disabled>", html) == 1
+    end
+
+    @testset "pixelmatch_report end-to-end" begin
+        dir = mktempdir()
+
+        out = joinpath(dir, "report.html")
+        stem = joinpath(dir, "case")
+        cp(joinpath(_FIX, "1a.png"), stem * "_ref.png")
+        @pixelmatch_report enabled = true out_file = out begin
+            @test fails() do
+                @test_pixelmatch stem _img("1b") threshold = 0.05
+            end
+        end
+        @test isfile(out)
+        @test occursin("data:image/png;base64,", read(out, String))
+
+        out_pass = joinpath(dir, "report_pass.html")
+        pass_stem = joinpath(dir, "passing")
+        cp(joinpath(_FIX, "1a.png"), pass_stem * "_ref.png")
+        @pixelmatch_report enabled = true out_file = out_pass begin
+            @test_pixelmatch pass_stem _img("1a")
+        end
+        @test !isfile(out_pass)
+
+        out_disabled = joinpath(dir, "report_disabled.html")
+        dis_stem = joinpath(dir, "disabled")
+        cp(joinpath(_FIX, "1a.png"), dis_stem * "_ref.png")
+        @pixelmatch_report enabled = false out_file = out_disabled begin
+            @test fails() do
+                @test_pixelmatch dis_stem _img("1b") threshold = 0.05
+            end
+        end
+        @test !isfile(out_disabled)
+        @test ACTIVE_COLLECTOR[] === nothing
+
+        @test (@pixelmatch_report enabled = false begin
+            41 + 1
+        end) == 42
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -261,3 +261,5 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, read(p.path))
         end
     end
 end
+
+include("report_tests.jl")


### PR DESCRIPTION
I've wanted the same thing in every repo that uses PixelMatch: when reference tests fail on CI, collect the offending images into an artifact so I can download and check them. So far I've done it by hand in each repo by globbing for `_diff.png` files, which silently misses failures that produce no diff, namely size mismatches and missing references.

`@pixelmatch_report` does it from the package. Wrap your `@test_pixelmatch` calls in it and, if any fail, it writes one self-contained HTML file with every failing comparison embedded, where you can toggle reference/recorded and view the diff:

```julia
PixelMatch.@pixelmatch_report enabled=get(ENV, "CI", "false") == "true" out_file=joinpath(@__DIR__, "pixelmatch-report.html") begin
    @test_pixelmatch "references/plot_a" render(fig_a)
    @test_pixelmatch "references/plot_b" render(fig_b)
end
```

<img width="1700" height="520" alt="pixelmatch report gallery" src="https://github.com/user-attachments/assets/1aee7fc6-8fa1-413e-a928-5a17259e0a1a">

It's a macro so it only wraps the block in a `try`/`finally` in place, no closure or extra stack frame, and failures are recorded in-process. That avoids a separate step that has to load PixelMatch, which is awkward when it's only a test dependency. Because recording keys off the failed test rather than the presence of a `_diff.png`, it catches every failure mode, including the size-mismatch and missing-reference cases the glob approach missed.

The HTML inlines its CSS/JS and embeds images as base64 so it renders on its own, and with `actions/upload-artifact@v7`'s `archive: false`, GitHub can open it in the browser directly. Images honor the PNG `pHYs` chunk so 2× HiDPI renders show at their intended physical size. CI side is one step (`if-no-files-found: ignore` because tests can fail for reasons unrelated to reference images, in which case no report is written):

```yaml
- uses: actions/upload-artifact@v7
  if: failure()
  with:
    name: pixelmatch-report
    path: test/pixelmatch-report.html
    archive: false
    if-no-files-found: ignore
```

This PR's own CI uploads an example `pixelmatch-report` artifact, generated from deliberate failures in the test suite, so you can download it from the run here and check the whole workflow end to end.
