### PR TITLE
fix(report): Lay out one comparison per row in HTML gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added `@pixelmatch_report`, which wraps a block of `@test_pixelmatch` calls and writes a self-contained HTML report of all failing comparisons for CI artifact upload. [#8](https://github.com/jkrumbiegel/PixelMatch.jl/pull/8)
+- The `@pixelmatch_report` gallery now lays out one comparison per row to stop images from jumping between rows on toggle. [#9](https://github.com/jkrumbiegel/PixelMatch.jl/pull/9)
 
 ## 1.4.0 - 2026-05-13
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PixelMatch"
 uuid = "433bd86c-62cb-491d-a348-72c5c8365002"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
 
 [deps]

--- a/src/report_template.html
+++ b/src/report_template.html
@@ -10,7 +10,7 @@ body { font-family: -apple-system, system-ui, Segoe UI, Arial, sans-serif; margi
 header { padding: 16px 24px; border-bottom: 1px solid #30363d; }
 header h1 { margin: 0 0 4px; font-size: 18px; }
 header p { margin: 0; color: #8b949e; }
-.gallery { display: flex; flex-wrap: wrap; align-items: flex-start; gap: 16px; padding: 24px; }
+.gallery { display: flex; flex-direction: column; align-items: flex-start; gap: 16px; padding: 24px; }
 .card { border: 1px solid #30363d; border-radius: 8px; background: #161b22; overflow: hidden; display: flex; flex-direction: column; min-width: 0; max-width: 100%; }
 .card-head { display: flex; flex-direction: column; gap: 2px; padding: 10px 12px; border-bottom: 1px solid #30363d; }
 .name { font-weight: 600; overflow-wrap: anywhere; }


### PR DESCRIPTION
The report gallery used `flex-wrap`, so when an image's displayed size changed on toggle (reference vs recorded vs diff), cards could reflow and jump between rows. Switching the gallery to a single column keeps each comparison fixed in place.
