### PR TITLE
feat(test_macro): Accept a file path as the recorded image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.6.0 - 2026-07-16
 
 - `@test_pixelmatch` accepts a path to an existing PNG file as the recorded image, copying it verbatim so metadata like the `pHYs` DPI chunk is preserved. [#10](https://github.com/jkrumbiegel/PixelMatch.jl/pull/10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 ## Unreleased
 
 - `@test_pixelmatch` accepts a path to an existing PNG file as the recorded image, copying it verbatim so metadata like the `pHYs` DPI chunk is preserved. [#10](https://github.com/jkrumbiegel/PixelMatch.jl/pull/10)
-- Added `@pixelmatch_report`, which wraps a block of `@test_pixelmatch` calls and writes a self-contained HTML report of all failing comparisons for CI artifact upload. [#8](https://github.com/jkrumbiegel/PixelMatch.jl/pull/8)
+
+## 1.5.1 - 2026-06-09
+
 - The `@pixelmatch_report` gallery now lays out one comparison per row to stop images from jumping between rows on toggle. [#9](https://github.com/jkrumbiegel/PixelMatch.jl/pull/9)
+
+## 1.5.0 - 2026-06-09
+
+- Added `@pixelmatch_report`, which wraps a block of `@test_pixelmatch` calls and writes a self-contained HTML report of all failing comparisons for CI artifact upload. [#8](https://github.com/jkrumbiegel/PixelMatch.jl/pull/8)
 
 ## 1.4.0 - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `@test_pixelmatch` accepts a path to an existing PNG file as the recorded image, copying it verbatim so metadata like the `pHYs` DPI chunk is preserved. [#10](https://github.com/jkrumbiegel/PixelMatch.jl/pull/10)
 - Added `@pixelmatch_report`, which wraps a block of `@test_pixelmatch` calls and writes a self-contained HTML report of all failing comparisons for CI artifact upload. [#8](https://github.com/jkrumbiegel/PixelMatch.jl/pull/8)
 - The `@pixelmatch_report` gallery now lays out one comparison per row to stop images from jumping between rows on toggle. [#9](https://github.com/jkrumbiegel/PixelMatch.jl/pull/9)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PixelMatch"
 uuid = "433bd86c-62cb-491d-a348-72c5c8365002"
-version = "1.5.1"
+version = "1.6.0"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
 
 [deps]

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -4,6 +4,10 @@
 Compare an image against a reference file using PixelMatch. The `name` should be
 the path stem without extension (`_suffix.png` is added automatically).
 
+The `image` can be an image matrix, an object `show`-able as `image/png`, or a
+path to an existing PNG file. A path is copied to the recorded file verbatim,
+which preserves metadata such as the `pHYs` DPI chunk.
+
 Files created:
 - `name_ref.png` - reference image
 - `name_rec.png` - recorded/actual image (when test runs)
@@ -88,6 +92,9 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
 
     if obj_to_record isa AbstractMatrix{<:Colorant}
         PNGFiles.save(rec_path, obj_to_record)
+    elseif obj_to_record isa AbstractString
+        isfile(obj_to_record) || error("the recorded image path is not an existing file: $obj_to_record")
+        cp(obj_to_record, rec_path; force = true)
     else
         open(rec_path, "w") do io
             show(io, MIME"image/png"(), obj_to_record)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,6 +172,18 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, read(p.path))
                 # check if an object that can be shown as image/png also works
                 @test_pixelmatch joinpath(foldername, "matching") PNG(joinpath(test_dir, "matching_ref.png"))
 
+                @testset "path as recorded image" begin
+                    cp(joinpath(@__DIR__, "fixtures", "1a.png"), joinpath(test_dir, "from_path_ref.png"))
+                    source_path = joinpath(test_dir, "from_path_source.png")
+                    cp(joinpath(@__DIR__, "fixtures", "1a.png"), source_path)
+                    @test_pixelmatch joinpath(foldername, "from_path") source_path
+                    @test read(joinpath(test_dir, "from_path_rec.png")) == read(source_path)
+
+                    @test_throws_message "not an existing file" begin
+                        @test_pixelmatch joinpath(foldername, "from_missing_path") joinpath(test_dir, "nonexistent.png")
+                    end
+                end
+
                 # copy same image as before to a different name to get different rec/diff images
                 ref_path2 = joinpath(test_dir, "different_ref.png")
                 cp(joinpath(@__DIR__, "fixtures", "1a.png"), ref_path2)


### PR DESCRIPTION
`@test_pixelmatch` always re-encodes the recorded image via `PNGFiles.save` or `show`, which drops PNG metadata. When the recording already exists as a file on disk (e.g. pages rasterized from a PDF with `pdftoppm`), this lost the `pHYs` DPI chunk, so the `@pixelmatch_report` gallery displayed the recorded image at a different size than reference and diff when toggling. Now an `AbstractString` argument is treated as a path to an existing PNG and copied verbatim to the rec file, keeping its metadata intact. A genuine DPI mismatch between reference and recording still shows up as different display sizes rather than being hidden.
