### PR TITLE
fix(test_macro): Copy the recorded file when updating after a size change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.1 - 2026-08-26
+
+- Updating a reference image after a size change now preserves PNG metadata such as the `pHYs` DPI chunk. [#11](https://github.com/jkrumbiegel/PixelMatch.jl/pull/11)
+
 ## 1.6.0 - 2026-07-16
 
 - `@test_pixelmatch` accepts a path to an existing PNG file as the recorded image, copying it verbatim so metadata like the `pHYs` DPI chunk is preserved. [#10](https://github.com/jkrumbiegel/PixelMatch.jl/pull/10)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PixelMatch"
 uuid = "433bd86c-62cb-491d-a348-72c5c8365002"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
 
 [deps]

--- a/src/test_macro.jl
+++ b/src/test_macro.jl
@@ -123,7 +123,7 @@ function _test_pixelmatch(path_stem::String, obj_to_record; test_pixel_mismatch:
             if size(img_ref) != size(recorded)
                 if update
                     @info "Reference size $(size(img_ref)) does not match recorded size $(size(recorded)) and JULIA_REFERENCETESTS_UPDATE=true, updating reference image"
-                    PNGFiles.save(ref_path, recorded)
+                    cp(rec_path, ref_path; force = true)
                 else
                     Test.@test size(img_ref) == size(recorded) broken=broken
                     broken || _record_failure(; name, status = :size_mismatch, ref_path, rec_path,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,6 +212,18 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, read(p.path))
                     @test_pixelmatch joinpath(foldername, "size_mismatch") size_mismatch_image
                 end
 
+                @testset "size mismatch update copies the recorded file verbatim" begin
+                    cp(joinpath(@__DIR__, "fixtures", "1a.png"), joinpath(test_dir, "size_update_ref.png"))
+                    source_path = joinpath(test_dir, "size_update_source.png")
+                    PNGFiles.save(source_path, fill(RGBA(0.5, 0.5, 0.5, 1.0), 5, 5); dpi = (96, 96))
+                    withenv("JULIA_REFERENCETESTS_UPDATE" => "true") do
+                        @test_pixelmatch joinpath(foldername, "size_update") source_path
+                    end
+                    updated_ref = read(joinpath(test_dir, "size_update_ref.png"))
+                    @test updated_ref == read(source_path)
+                    @test updated_ref == read(joinpath(test_dir, "size_update_rec.png"))
+                end
+
                 @testset "skip keyword" begin
                     # skip=true must not evaluate the image expression, must not write
                     # files, must not fail even when no reference exists, and must


### PR DESCRIPTION
Every reference update in `_test_pixelmatch` copies the recorded file verbatim, except the size-mismatch branch under `JULIA_REFERENCETESTS_UPDATE=true`, which did `PNGFiles.save(ref_path, recorded)` on the decoded matrix. That re-encode drops all ancillary PNG chunks, in particular `pHYs`, which Makie writes (`px_per_unit * 96` dpi) into everything shown as `image/png`.

So a reference lost its DPI metadata the first time a plot changed pixel dimensions, and only got it back at its next same-size update. In a suite with many references that leaves an unpredictable mix of references with and without `pHYs`, even within one commit, and image viewers then size the two sides of a diff differently: the 96 dpi one gets scaled to its physical size on a HiDPI screen, the other is rendered at whatever default the viewer assumes.

Also releases this as 1.6.1.
